### PR TITLE
Don't define int types when compiling with MinGW.

### DIFF
--- a/libcoda/coda.h.in
+++ b/libcoda/coda.h.in
@@ -33,9 +33,9 @@ extern "C"
 #ifdef WIN32
 #include <windows.h>
 
-#if (_MSC_VER < 1600)
-/* For Visual Studio we can use stdint.h as of Visual Studio 2010
- * For earlier versions we need to provide our own defines
+#if (_MSC_VER < 1600) && !defined(__MINGW32__)
+/* For Visual Studio > 2010 and MinGW we can use stdint.h
+ * For earlier versions of Visual Studio we need to provide our own defines
  */
 #ifndef int8_t
 #define int8_t  signed char


### PR DESCRIPTION
MinGW also provides stdint.h, so these definitions cause conflicts.

(I edited coda.h.in, I'm not so familiar with CMake so I didn't touch coda.h.cmake.in)