### PR TITLE
Configure option to disable installation of docs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -678,6 +678,7 @@ endif
 
 # *** documentation ***
 
+if INSTALL_DOCS
 include doclibcoda.mk
 include docjava.mk
 
@@ -789,7 +790,7 @@ docjava_include:
 	else \
 	  mv docjava.mk2 $(srcdir)/docjava.mk ; \
 	fi
-
+endif
 
 # *** indent ***
 

--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,14 @@ AC_FUNC_REALLOC
 AC_CHECK_FUNCS([floor pread stat memmove bcopy])
 AC_REPLACE_FUNCS([strdup strcasecmp strncasecmp vsnprintf])
 
+# ** install documentation ***
+
+AC_ARG_ENABLE([install-docs],
+        [AS_HELP_STRING([--disable-install-docs],[do not install html docs])],
+        [ac_cv_enable_install_docs=$enableval],
+        [AC_CACHE_CHECK([install docs],ac_cv_enable_install_docs,ac_cv_enable_install_docs=yes)])
+AM_CONDITIONAL(INSTALL_DOCS, test $ac_cv_enable_install_docs = yes)
+
 # *** sub-package mode ***
 
 AC_ARG_ENABLE([coda-subpackage-mode],


### PR DESCRIPTION
I'd like an option to not install the documentation. This patch is what I'm currently using to do that, but my autotools experience is limited...