### PR TITLE
check_file(): fix check for product_type == NULL

### DIFF
--- a/tools/codacheck/codacheck.c
+++ b/tools/codacheck/codacheck.c
@@ -129,7 +129,7 @@ static void check_file(char *filename)
         return;
     }
 
-    if (option_require_definition && (product_class == NULL || product_class == NULL))
+    if (option_require_definition && (product_class == NULL || product_type == NULL))
     {
         printf("  ERROR: could not determine product type\n\n");
         found_errors = 1;


### PR DESCRIPTION
cppcheck --enable=all --std=c99 --force codacheck.c
[codacheck.c:132] -> [codacheck.c:132]: (style) Same expression on both sides of '||'.

using cppcheck 1.81