### PR TITLE
Add include code.h to several headers to allow them to stand on their own.

### DIFF
--- a/libcoda/coda-read-array.h
+++ b/libcoda/coda-read-array.h
@@ -32,6 +32,8 @@
 #ifndef CODA_READ_ARRAY_H
 #define CODA_READ_ARRAY_H
 
+#include "coda.h"
+
 #ifndef CODA_READ_FUNC_TYPE_DEF
 #define CODA_READ_FUNC_TYPE_DEF
 typedef int (*read_function) (const coda_cursor *, void *);

--- a/libcoda/coda-read-partial-array.h
+++ b/libcoda/coda-read-partial-array.h
@@ -32,6 +32,8 @@
 #ifndef CODA_READ_PARTIAL_ARRAY_H
 #define CODA_READ_PARTIAL_ARRAY_H
 
+#include "coda.h"
+
 #ifndef CODA_READ_FUNC_TYPE_DEF
 #define CODA_READ_FUNC_TYPE_DEF
 typedef int (*read_function) (const coda_cursor *, void *);

--- a/libcoda/coda-transpose-array.h
+++ b/libcoda/coda-transpose-array.h
@@ -32,6 +32,8 @@
 #ifndef CODA_TRANSPOSE_ARRAY_H
 #define CODA_TRANSPOSE_ARRAY_H
 
+#include "coda.h"
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This is needed for some optimizing compilers that pre-parse headers separately.
e.g. some variants of llvm