### PR TITLE
ziparchive.c: Require get_entries() read to get the full filename.

### DIFF
--- a/libcoda/ziparchive.c
+++ b/libcoda/ziparchive.c
@@ -277,7 +277,8 @@ static int get_entries(za_file *zf)
             return -1;
         }
 
-        if (read(zf->fd, entry->filename, entry->filename_length) < 0)
+        const ssize_t len = read(zf->fd, entry->filename, entry->filename_length);
+        if (len != entry->filename_length)
         {
             zf->handle_error(strerror(errno));
             return -1;


### PR DESCRIPTION
Fixes #69