### PR TITLE
ziparchive.c: Add missing free to za_read_entry() when there is an unexpected end of the zip file.

### DIFF
--- a/libcoda/ziparchive.c
+++ b/libcoda/ziparchive.c
@@ -655,6 +655,7 @@ int za_read_entry(za_entry *entry, char *out_buffer)
         if (((uint32_t)result) != entry->compressed_size)
         {
             entry->zf->handle_error("unexpected end in zip file");
+            free(in_buffer);
             return -1;
         }
 


### PR DESCRIPTION
```
#1 0x55e8db2d9085 in coda_za_read_entry third_party/stcorp_coda/libcoda/ziparchive.c:641:21
--
  | #2 0x55e8db1ce8dc in parse_entry third_party/stcorp_coda/libcoda/coda-definition-parse.c:4170:9
  | #3 0x55e8db1cfab9 in read_definition_file third_party/stcorp_coda/libcoda/coda-definition-parse.c:4263:9
  | #4 0x55e8db1cf8a1 in coda_read_definitions third_party/stcorp_coda/libcoda/coda-definition-parse.c:4471:21
  | #5 0x55e8db187fa9 in LLVMFuzzerTestOneInput third_party/stcorp_coda/fuzz/coda_read_definitions_fuzzer.cc:19:3
```

[testcase-6585686393356288.zip](https://github.com/stcorp/coda/files/4686948/testcase-6585686393356288.zip)
