### PR TITLE
read_grib2_message: Add missing delete when 'list of numbers' should not be present

### DIFF
--- a/libcoda/coda-grib.c
+++ b/libcoda/coda-grib.c
@@ -2542,6 +2542,7 @@ static int read_grib2_message(coda_grib_product *product, coda_mem_record *messa
                     {
                         coda_set_error(CODA_ERROR_PRODUCT, "'list of numbers' in GDS should only be present if Ni or "
                                        "Nj have a MISSING value (4294967295)");
+                        coda_dynamic_type_delete((coda_dynamic_type *)grid);
                         return -1;
                     }
 


### PR DESCRIPTION
```
==2131351==ERROR: LeakSanitizer: detected memory leaks
--
  |  
  | Direct leak of 48 byte(s) in 1 object(s) allocated from:
  | #1 0x561fcdd93885 in coda_mem_record_new third_party/stcorp_coda/libcoda/coda-mem-type.c:442:31
  | #2 0x561fcdd6f263 in read_grib2_message third_party/stcorp_coda/libcoda/coda-grib.c:2371:20
  | #3 0x561fcdd5eba0 in coda_grib_reopen third_party/stcorp_coda/libcoda/coda-grib.c:3134:17
  | #4 0x561fcdda0dcb in reopen_with_backend third_party/stcorp_coda/libcoda/coda-product.c:410:17
  | #5 0x561fcdd9dbb8 in open_file third_party/stcorp_coda/libcoda/coda-product.c:552:9
  | #6 0x561fcdd9d4fa in coda_recognize_file third_party/stcorp_coda/libcoda/coda-product.c:596:9
  | #7 0x561fcdcb01f1 in LLVMFuzzerTestOneInput third_party/stcorp_coda/fuzz/coda_recognize_file_fuzzer.cc:19:3
```

Found with autofuzz / clusterfuzz

[testcase-5752025008832512.zip](https://github.com/stcorp/coda/files/4705186/testcase-5752025008832512.zip)

