### PR TITLE
Initializing variable which may be used in an uninitialized fashion (closes #80)

### DIFF
--- a/libcoda/coda-definition-parse.c
+++ b/libcoda/coda-definition-parse.c
@@ -4149,7 +4149,7 @@ static int parse_entry(za_file *zf, zip_entry_type type, const char *name, coda_
     info.product_definition = current_product_definition;
 
     filesize = za_get_entry_size(entry);
-    info.buffer = malloc(filesize);
+    info.buffer = calloc(filesize, sizeof(char));
     if (info.buffer == NULL)
     {
         coda_set_error(CODA_ERROR_OUT_OF_MEMORY, "out of memory (could not allocate %lu bytes) (%s:%u)",


### PR DESCRIPTION
Initializing variable which may be used in an uninitialized fashion as reported by the test case included in issue #80. 

Using uninitialized memory can be a security issue, such as potentially leaking previous stack contents. By zero-initializing, we avoid such potential leaks.

Running with the specific input case after this PR is applied no longer results in any error findings (credits: the input case was found using google/clusterfuzz).

Note that this PR only avoids the uninitialized memory use identified in that bug, and is unaware of the functionality or semantics of the rest of the code. The file owners are welcome to suggest alternate fixes on this PR or address other behavioral concerns in a separate PR.

(For the record: I am currently a Visiting Researcher at Google NYC and this fix is the result of an internal project). 